### PR TITLE
Add missing dependency to embedded example

### DIFF
--- a/jetty-documentation/src/main/asciidoc/development/embedding/embedded-examples.adoc
+++ b/jetty-documentation/src/main/asciidoc/development/embedding/embedded-examples.adoc
@@ -71,7 +71,12 @@ To use this example in your project, you will need the following Maven dependenc
   <groupId>org.eclipse.jetty</groupId>
   <artifactId>apache-jstl</artifactId>
   <version>${project.version}</version>
-</dependency>     
+</dependency>
+<dependency>
+  <groupId>org.eclipse.jetty</groupId>
+  <artifactId>jetty-jmx</artifactId>
+  <version>${project.version}</version>
+</dependency>
 ----
 
 [[adding-embedded-examples]]


### PR DESCRIPTION
`MBeanContainer` is included in jetty-jmx, so the dependency should be listed in the example
